### PR TITLE
parse stops json, create and save stop entities

### DIFF
--- a/main-app/src/main/java/com/nyctransittracker/mainapp/MainAppApplication.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/MainAppApplication.java
@@ -7,22 +7,20 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-import java.io.IOException;
-
 @SpringBootApplication
 @EnableConfigurationProperties(RedisProperties.class)
 public class MainAppApplication {
 
-	@Autowired
-	private static StationFetcher stationFetcher;
+//	private final StationFetcher stationFetcher;
 
-	public MainAppApplication(StationFetcher stationFetcher) {
-		this.stationFetcher = stationFetcher;
-	}
+//	@Autowired
+//	public MainAppApplication(StationFetcher stationFetcher) {
+//		this.stationFetcher = stationFetcher;
+//	}
 
-	public static void main(String[] args) throws IOException {
+	public static void main(String[] args) {
 		SpringApplication.run(MainAppApplication.class, args);
-		stationFetcher.fetchStations();
+//		stationFetcher.fetchStations();
 	}
 
 }

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/MainAppApplication.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/MainAppApplication.java
@@ -1,16 +1,29 @@
 package com.nyctransittracker.mainapp;
 
 import com.nyctransittracker.mainapp.config.RedisProperties;
+import com.nyctransittracker.mainapp.util.StationFetcher;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import java.io.IOException;
 
 @SpringBootApplication
 @EnableConfigurationProperties(RedisProperties.class)
 public class MainAppApplication {
 
-	public static void main(String[] args) {
+	@Autowired
+	private static StationFetcher stationFetcher;
+
+	public MainAppApplication(StationFetcher stationFetcher) {
+		this.stationFetcher = stationFetcher;
+	}
+
+	public static void main(String[] args) throws IOException {
 		SpringApplication.run(MainAppApplication.class, args);
+		stationFetcher.fetchStations();
 	}
 
 }
+

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/entity/Stop.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/entity/Stop.java
@@ -21,6 +21,8 @@ import java.util.Map;
 public class Stop {
     @Id
     @Column(name="ID", length=50, nullable=false)
+    private Long uniqueId;
+    @Column(name="STOP_ID", length=50, nullable=false)
     @JsonProperty("id")
     private String GTFSStopID;
     @Transient
@@ -32,7 +34,7 @@ public class Stop {
     @Column(name="NAME", length=50, nullable=false, unique=false)
     private String name;
     @Column(name="LATITUDE", length=50, nullable=false, unique=false)
-    private String latitude;
+    private Double latitude;
     @Column(name="LONGITUDE", length=50, nullable=false, unique=false)
-    private String longitude;
+    private Double longitude;
 }

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/entity/Stop.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/entity/Stop.java
@@ -1,0 +1,38 @@
+package com.nyctransittracker.mainapp.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+
+@Entity
+@Table(name="STOP")
+
+public class Stop {
+    @Id
+    @Column(name="ID", length=50, nullable=false)
+    @JsonProperty("id")
+    private String GTFSStopID;
+    @Transient
+    private Map<String, List> routes;
+    @Column(name="ROUTE", length=50, nullable=false, unique=false)
+    private String route;
+    @Column(name="DIRECTION", length=50, nullable=false, unique=false)
+    private String direction;
+    @Column(name="NAME", length=50, nullable=false, unique=false)
+    private String name;
+    @Column(name="LATITUDE", length=50, nullable=false, unique=false)
+    private String latitude;
+    @Column(name="LONGITUDE", length=50, nullable=false, unique=false)
+    private String longitude;
+}

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/model/StationResponse.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/model/StationResponse.java
@@ -1,0 +1,18 @@
+package com.nyctransittracker.mainapp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nyctransittracker.mainapp.entity.Stop;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class StationResponse {
+    private int timestamp;
+    @JsonProperty("stops")
+    private List<Stop> stops;
+}

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/model/StationResponse.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/model/StationResponse.java
@@ -1,7 +1,6 @@
 package com.nyctransittracker.mainapp.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.nyctransittracker.mainapp.entity.Stop;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/model/StationResponse.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/model/StationResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @Data
 public class StationResponse {
-    private int timestamp;
+    private long timestamp;
     @JsonProperty("stops")
     private List<Stop> stops;
 }

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/model/Stop.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/model/Stop.java
@@ -1,4 +1,4 @@
-package com.nyctransittracker.mainapp.entity;
+package com.nyctransittracker.mainapp.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -20,8 +20,8 @@ import java.util.Map;
 
 public class Stop {
     @Id
-    @Column(name="ID", length=50, nullable=false)
-    private Long uniqueId;
+    @Column(name = "id")
+    private String uniqueId;
     @Column(name="STOP_ID", length=50, nullable=false)
     @JsonProperty("id")
     private String GTFSStopID;

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/repository/StopRepository.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/repository/StopRepository.java
@@ -1,6 +1,6 @@
 package com.nyctransittracker.mainapp.repository;
 
-import com.nyctransittracker.mainapp.entity.Stop;
+import com.nyctransittracker.mainapp.model.Stop;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StopRepository

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/repository/StopRepository.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/repository/StopRepository.java
@@ -1,0 +1,8 @@
+package com.nyctransittracker.mainapp.repository;
+
+import com.nyctransittracker.mainapp.entity.Stop;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StopRepository
+        extends JpaRepository<Stop, String> {
+}

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/service/StopService.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/service/StopService.java
@@ -1,0 +1,23 @@
+package com.nyctransittracker.mainapp.service;
+
+import com.nyctransittracker.mainapp.entity.Stop;
+import com.nyctransittracker.mainapp.repository.StopRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StopService {
+
+    private final StopRepository repository;
+    public void createStation(Stop stop, String direction, String route) {
+        var newStop = new Stop();
+        newStop.setGTFSStopID(stop.getGTFSStopID());
+        newStop.setName(stop.getName());
+        newStop.setLatitude(stop.getLatitude());
+        newStop.setLongitude(stop.getLongitude());
+        newStop.setDirection(direction);
+        newStop.setRoute(route);
+        repository.save(newStop);
+    }
+}

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/service/StopService.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/service/StopService.java
@@ -5,6 +5,8 @@ import com.nyctransittracker.mainapp.repository.StopRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Random;
+
 @Service
 @RequiredArgsConstructor
 public class StopService {
@@ -12,6 +14,7 @@ public class StopService {
     private final StopRepository repository;
     public void createStation(Stop stop, String direction, String route) {
         var newStop = new Stop();
+        newStop.setUniqueId(new Random().nextLong());
         newStop.setGTFSStopID(stop.getGTFSStopID());
         newStop.setName(stop.getName());
         newStop.setLatitude(stop.getLatitude());

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/service/StopService.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/service/StopService.java
@@ -1,11 +1,9 @@
 package com.nyctransittracker.mainapp.service;
 
-import com.nyctransittracker.mainapp.entity.Stop;
+import com.nyctransittracker.mainapp.model.Stop;
 import com.nyctransittracker.mainapp.repository.StopRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -14,7 +12,7 @@ public class StopService {
     private final StopRepository repository;
     public void createStation(Stop stop, String direction, String route) {
         var newStop = new Stop();
-        newStop.setUniqueId(new Random().nextLong());
+        newStop.setUniqueId(stop.getGTFSStopID().toString() + route + direction);
         newStop.setGTFSStopID(stop.getGTFSStopID());
         newStop.setName(stop.getName());
         newStop.setLatitude(stop.getLatitude());

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/util/StationFetcher.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/util/StationFetcher.java
@@ -1,9 +1,12 @@
 package com.nyctransittracker.mainapp.util;
 
+import com.nyctransittracker.mainapp.MainAppApplication;
 import com.nyctransittracker.mainapp.entity.Stop;
 import com.nyctransittracker.mainapp.model.StationResponse;
 import com.nyctransittracker.mainapp.service.StopService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
 import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -13,11 +16,16 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class StationFetcher {
+public class StationFetcher implements CommandLineRunner {
     private final static String url = "https://www.goodservice.io/api/stops/";
     private final StopService service;
 
     ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void run(String... args) throws IOException {
+        fetchStations();
+    }
 
     public void fetchStations() throws IOException {
         StationResponse stationResponse =

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/util/StationFetcher.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/util/StationFetcher.java
@@ -1,0 +1,34 @@
+package com.nyctransittracker.mainapp.util;
+
+import com.nyctransittracker.mainapp.entity.Stop;
+import com.nyctransittracker.mainapp.model.StationResponse;
+import com.nyctransittracker.mainapp.service.StopService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StationFetcher {
+    private final static String url = "https://www.goodservice.io/api/stops/";
+    private final StopService service;
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    public void fetchStations() throws IOException {
+        StationResponse stationResponse =
+                mapper.readValue(new URL(url), StationResponse.class);
+        List<Stop> stops = stationResponse.getStops();
+        stops.forEach(stop ->
+                stop.getRoutes().forEach((route, dList) ->
+                            dList.forEach(d ->
+                                    service.createStation(stop, d.toString(), route.toString())
+                        )
+                )
+        );
+    }
+}

--- a/main-app/src/main/java/com/nyctransittracker/mainapp/util/StationFetcher.java
+++ b/main-app/src/main/java/com/nyctransittracker/mainapp/util/StationFetcher.java
@@ -1,12 +1,10 @@
 package com.nyctransittracker.mainapp.util;
 
-import com.nyctransittracker.mainapp.MainAppApplication;
-import com.nyctransittracker.mainapp.entity.Stop;
+import com.nyctransittracker.mainapp.model.Stop;
 import com.nyctransittracker.mainapp.model.StationResponse;
 import com.nyctransittracker.mainapp.service.StopService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
 import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -20,7 +18,7 @@ public class StationFetcher implements CommandLineRunner {
     private final static String url = "https://www.goodservice.io/api/stops/";
     private final StopService service;
 
-    ObjectMapper mapper = new ObjectMapper();
+    private static ObjectMapper mapper = new ObjectMapper();
 
     @Override
     public void run(String... args) throws IOException {


### PR DESCRIPTION
Main application calls good service endpoint to get all station information. Then station information is parsed to create separate stop for each direction per each route. The stop is mapped to an entity and saved in the database.

Can be checked by visiting the console in planetscale and query `SELECT * from stop;`.